### PR TITLE
Quality AddModuleScore_UCell

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -124,7 +124,7 @@ score.computing.for.scGate <- function(data, model, ncores=1, assay="RNA", add.s
      signatures <- append(signatures, add.sign)
   } 
   
-  data <- AddModuleScore_UCell(data, features = signatures, ncores=ncores, storeRanks = keep.ranks)
+  data <- UCell::AddModuleScore_UCell(data, features = signatures, ncores=ncores, storeRanks = keep.ranks)
   
   return(data)
 }


### PR DESCRIPTION
In some limited testing I did locally, it seemed like users of scGate needed to manually call "library(UCell)" before using scGate. I dont see any imports in NAMESPACE, so this PR qualifies UCell::AddModuleScore_UCell, which I think might fix this.